### PR TITLE
Add CI workflow and simple test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff pytest pyinstaller
+      - name: Lint
+        run: ruff .
+      - name: Test
+        run: pytest -q
+      - name: Build executable
+        run: python -m PyInstaller --onefile --noconsole phase_0_complements_app.py

--- a/drill.py
+++ b/drill.py
@@ -1,0 +1,7 @@
+from phase_0_complements_app import BaseDrill, ComplementDrill, TenMinusDrill
+
+__all__ = [
+    "BaseDrill",
+    "ComplementDrill",
+    "TenMinusDrill",
+]

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import drill
+
+
+def test_disp():
+    assert drill.ComplementDrill().disp(3) == "3"


### PR DESCRIPTION
## Summary
- add `drill` helper module so tests can import ComplementDrill
- create a basic test for ComplementDrill
- set up GitHub Actions workflow running ruff, pytest, and building an executable with PyInstaller

## Testing
- `ruff check .`
- `pytest -q`
- `python -m PyInstaller --onefile --noconsole phase_0_complements_app.py` *(fails: No module named PyInstaller)*

------
https://chatgpt.com/codex/tasks/task_e_686b1eacf3a0832d9ee26b9e6779e58e