### PR TITLE
Fix script execution mode in GUI

### DIFF
--- a/src/app/gui.py
+++ b/src/app/gui.py
@@ -9,7 +9,16 @@
 import tkinter as tk
 from tkinter import ttk
 import time
-from .drill import ComplementDrill, TenMinusDrill
+import sys
+import os
+
+if __package__ is None:
+    sys.path.append(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    )
+    from drill import ComplementDrill, TenMinusDrill
+else:
+    from .drill import ComplementDrill, TenMinusDrill
 
 # ──────────────────────────────
 # 設定値


### PR DESCRIPTION
## Summary
- handle running `gui.py` directly as a script
- modify imports to work whether `__package__` is set or not

## Testing
- `pytest -q`
- `python src/app/gui.py` *(fails: no display name and no $DISPLAY environment variable)*
- `python -m src.app.gui` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_686b297bd534832d8610aa87c7ecc1cb