### PR TITLE
Add BaseDrill tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -1,0 +1,29 @@
+import random
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from app.drill import BaseDrill
+
+
+def test_base_drill_regen_counts():
+    random.seed(0)
+    d = BaseDrill()
+    q = d.q
+    assert len(q) == 20
+    for n in range(1, 10):
+        assert q.count(n) >= 2
+
+
+def test_next_cycles_and_regenerates():
+    random.seed(0)
+    d = BaseDrill()
+    q_initial = d.q.copy()
+
+    results = [d.next() for _ in range(25)]
+
+    # first 20 values come from the initial queue in reverse order
+    assert results[:20] == q_initial[::-1]
+    # after consuming 25 items, 5 should remain in the new queue
+    assert len(d.q) == 15


### PR DESCRIPTION
## Summary
- add unit tests for `BaseDrill`
- run tests automatically via GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2b772a50832dbe9f0ea5e24072d6