### PR TITLE
Add Add2Digit1DigitDrill

### DIFF
--- a/src/app/drill.py
+++ b/src/app/drill.py
@@ -40,3 +40,38 @@ class TenMinusDrill(BaseDrill):
 
     def spk(self, v):
         pass
+
+
+class Add2Digit1DigitDrill(BaseDrill):
+    """Two-digit plus one-digit addition drill."""
+
+    def regen(self):
+        addends = _VALUES * 2 + random.sample(_VALUES, 2)
+        tens = _VALUES * 2 + random.sample(_VALUES, 2)
+        random.shuffle(addends)
+        random.shuffle(tens)
+
+        carry_indices = set(random.sample(range(20), 10))
+        q = []
+        for i in range(20):
+            a = addends[i]
+            t = tens[i]
+            if i in carry_indices:
+                ones = random.randint(10 - a, 9)
+            else:
+                ones = random.randint(0, 9 - a)
+            q.append((t * 10 + ones, a))
+
+        random.shuffle(q)
+        for i in range(len(q) - 1):
+            if q[i] == q[i + 1]:
+                swap = (i + 2) % len(q)
+                q[i + 1], q[swap] = q[swap], q[i + 1]
+        self.q = q
+
+    def disp(self, v):
+        left, right = v
+        return f"{left}+{right}"
+
+    def spk(self, v):
+        pass

--- a/src/app/gui.py
+++ b/src/app/gui.py
@@ -16,9 +16,9 @@ if __package__ is None:
     sys.path.append(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     )
-    from drill import ComplementDrill, TenMinusDrill
+    from drill import ComplementDrill, TenMinusDrill, Add2Digit1DigitDrill
 else:
-    from .drill import ComplementDrill, TenMinusDrill
+    from .drill import ComplementDrill, TenMinusDrill, Add2Digit1DigitDrill
 
 # ──────────────────────────────
 # 設定値

--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from app.drill import BaseDrill
+from app.drill import BaseDrill, Add2Digit1DigitDrill
 
 
 def test_base_drill_regen_counts():
@@ -27,3 +27,30 @@ def test_next_cycles_and_regenerates():
     assert results[:20] == q_initial[::-1]
     # after consuming 25 items, 5 should remain in the new queue
     assert len(d.q) == 15
+
+
+def test_add2digit1digitdrill_queue():
+    random.seed(0)
+    d = Add2Digit1DigitDrill()
+    q = d.q
+
+    assert len(q) == 20
+
+    addends = [b for _, b in q]
+    for n in range(1, 10):
+        assert addends.count(n) >= 2
+
+    tens = [a // 10 for a, _ in q]
+    for n in range(1, 10):
+        assert tens.count(n) >= 2
+
+    carry = sum(1 for a, b in q if a % 10 + b >= 10)
+    assert carry == 10
+
+    for x, y in zip(q, q[1:]):
+        assert x != y
+
+
+def test_add2digit1digitdrill_disp():
+    d = Add2Digit1DigitDrill()
+    assert d.disp((52, 7)) == "52+7"


### PR DESCRIPTION
## Summary
- implement `Add2Digit1DigitDrill` for two-digit plus one-digit drills
- import the new drill class inside `gui.py`
- test queue generation and formatting of `Add2Digit1DigitDrill`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2e8750f4832d81248169044eda8a