### PR TITLE
Add history graph window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.5.0] - 2025-07-10
+- Added HistoryWindow with matplotlib graph and session list.
+- Added pandas and matplotlib as dependencies.
+- CSV log renamed to `reflex_log.csv`.
+
 ## [v0.4.0] - 2025-07-09
 - Mode C two-digit terms exclude multiples of ten.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ visible progress.
 ## Installation
 
 1. Ensure **Python 3.10** or newer is installed.
-2. No third‑party packages are required, but an empty `requirements.txt` is
-   provided for convenience:
+2. Install the required packages (`pandas` and `matplotlib`):
    ```bash
-   pip install -r requirements.txt  # optional, installs nothing
+   pip install -r requirements.txt
    ```
 
 ## Quick Start

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+matplotlib

--- a/src/app/gui.py
+++ b/src/app/gui.py
@@ -13,14 +13,13 @@ import sys
 import os
 import csv
 import datetime
+import pandas as pd
+from matplotlib import pyplot as plt
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
 if __package__ is None:
     sys.path.append(
-        os.path.dirname(
-            os.path.dirname(
-                os.path.dirname(os.path.abspath(__file__))
-            )
-        )
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     )
     from drill import (
         ComplementDrill,
@@ -42,7 +41,7 @@ _FONT_MSG = ("Yu Gothic", 60, "bold")  # 開始・終了メッセージ
 _FONT_DLG = ("Consolas", 48)  # 遅延リスト
 _CARD_BG, _CARD_FG = "#222222", "#FFFFFF"
 _NUM_Q, _THRESH, _KPI = 20, 0.80, 0.80
-SESSION_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "session_log.csv")
+REFLEX_LOG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "reflex_log.csv")
 
 
 def log_session(csv_path, mode, avg, records):
@@ -53,13 +52,16 @@ def log_session(csv_path, mode, avg, records):
         writer = csv.writer(f)
         if not file_exists:
             writer.writerow(["date", "time", "mode", "avg_rt", "slow_count"])
-        writer.writerow([
-            datetime.date.today(),
-            datetime.datetime.now().strftime("%H:%M:%S"),
-            mode,
-            f"{avg:.2f}",
-            slow_count,
-        ])
+        writer.writerow(
+            [
+                datetime.date.today(),
+                datetime.datetime.now().strftime("%H:%M:%S"),
+                mode,
+                f"{avg:.2f}",
+                slow_count,
+            ]
+        )
+
 
 # ──────────────────────────────
 # GUI アプリ
@@ -151,6 +153,12 @@ class App(tk.Tk):
             state=tk.DISABLED,
         )
         self.reset_btn.pack(pady=8)
+        tk.Button(
+            side,
+            text="履歴グラフ",
+            width=18,
+            command=self.show_history,
+        ).pack(pady=(0, 8))
         tk.Label(side, text="Enter▶回答＆開始  Esc▶Reset", font=("Yu Gothic", 8)).pack()
 
     # bindings
@@ -197,7 +205,7 @@ class App(tk.Tk):
 
     def finish(self):
         avg = sum(rt for _, rt in self.records) / len(self.records)
-        log_session(SESSION_LOG, self.mode.get(), avg, self.records)
+        log_session(REFLEX_LOG, self.mode.get(), avg, self.records)
         self.session = False
         self.lbl.config(text=f"{_NUM_Q}問終了！\n平均 {avg:.2f} s", font=_FONT_MSG)
         self.stat.set(f"平均 RT: {avg:.2f} s")
@@ -234,6 +242,9 @@ class App(tk.Tk):
         win.transient(self)
         win.grab_set()
         self.wait_window(win)
+
+    def show_history(self):
+        HistoryWindow(self)
 
     def reset(self):
         self.session = False
@@ -277,6 +288,83 @@ class App(tk.Tk):
         avg = sum(rt for _, rt in self.records) / len(self.records)
         self.stat.set(f"平均 RT: {avg:.2f} s")
         self.stat_lbl.config(bg="#66CC66" if avg <= _KPI else "#CCCCCC")
+
+
+class HistoryWindow(tk.Toplevel):
+    def __init__(self, master):
+        super().__init__(master)
+        self.title("履歴グラフ")
+        self.df = self.load_data()
+
+        self.filter_var = tk.StringVar(value="all")
+        opt_frame = tk.Frame(self)
+        opt_frame.pack(pady=5)
+        for text, val in [
+            ("全モード表示", "all"),
+            ("モードAのみ", "A"),
+            ("モードBのみ", "B"),
+            ("モードCのみ", "C"),
+        ]:
+            tk.Radiobutton(
+                opt_frame,
+                text=text,
+                variable=self.filter_var,
+                value=val,
+                command=self.update_view,
+            ).pack(side=tk.LEFT)
+
+        self.fig, self.ax = plt.subplots(figsize=(5, 3), dpi=100)
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
+
+        cols = ("date", "time", "mode", "avg_rt", "slow_count")
+        self.tree = ttk.Treeview(self, columns=cols, show="headings", height=8)
+        for c in cols:
+            self.tree.heading(c, text=c)
+            self.tree.column(c, width=80, anchor=tk.CENTER)
+        self.tree.pack(fill=tk.BOTH, expand=True)
+
+        self.update_view()
+
+    def load_data(self):
+        if os.path.exists(REFLEX_LOG):
+            df = pd.read_csv(REFLEX_LOG)
+        else:
+            df = pd.DataFrame(columns=["date", "time", "mode", "avg_rt", "slow_count"])
+        if not df.empty:
+            df["date"] = pd.to_datetime(df["date"])
+            df["avg_rt"] = pd.to_numeric(df["avg_rt"], errors="coerce")
+        return df
+
+    def update_view(self):
+        if self.filter_var.get() == "all":
+            df = self.df
+        else:
+            df = self.df[self.df["mode"] == self.filter_var.get()]
+
+        self.ax.clear()
+        if not df.empty:
+            self.ax.plot(df["date"], df["avg_rt"], marker="o")
+        self.ax.axhline(0.8, color="red", linestyle="--")
+        self.ax.set_xlabel("date")
+        self.ax.set_ylabel("avg_rt")
+        self.fig.autofmt_xdate()
+        self.canvas.draw()
+
+        for i in self.tree.get_children():
+            self.tree.delete(i)
+        for _, row in df.iterrows():
+            self.tree.insert(
+                "",
+                "end",
+                values=(
+                    row["date"].strftime("%Y-%m-%d"),
+                    row["time"],
+                    row["mode"],
+                    row["avg_rt"],
+                    row["slow_count"],
+                ),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,6 +3,7 @@ import csv
 import datetime
 
 import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 import app.gui as gui
@@ -50,7 +51,7 @@ def read_csv_rows(path):
 
 def test_finish_creates_csv_with_header(tmp_path, monkeypatch):
     csv_path = tmp_path / "log.csv"
-    monkeypatch.setattr(gui, "SESSION_LOG", str(csv_path))
+    monkeypatch.setattr(gui, "REFLEX_LOG", str(csv_path))
 
     app = create_dummy_app("A", [("1", 1.0), ("2", 0.5)])
     app.finish()
@@ -69,7 +70,7 @@ def test_finish_appends_without_header(tmp_path, monkeypatch):
     with open(csv_path, "w", newline="") as f:
         csv.writer(f).writerow(["date", "time", "mode", "avg_rt", "slow_count"])
 
-    monkeypatch.setattr(gui, "SESSION_LOG", str(csv_path))
+    monkeypatch.setattr(gui, "REFLEX_LOG", str(csv_path))
 
     app = create_dummy_app("B", [("1", 0.1), ("2", 0.2)])
     app.finish()
@@ -79,4 +80,3 @@ def test_finish_appends_without_header(tmp_path, monkeypatch):
     assert len(rows) == 2
     assert rows[1][2] == "B"
     assert rows[1][3] == "0.15"
-


### PR DESCRIPTION
## Summary
- introduce `HistoryWindow` to plot session history with matplotlib
- rename CSV log file constant to `REFLEX_LOG`
- add a "履歴グラフ" button to open the new window
- document pandas/matplotlib requirements and bump changelog

## Testing
- `ruff check src tests`
- `black -q src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686b3b80bad8832dbf3be9b16771a94b