### PR TITLE
Enable session deletion from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ In addition to complement drills (modes A and B), **Mode C** serves two-digit pl
 one-digit addition problems. Two-digit numbers never end with zero (10, 20, ... 90
 are excluded) and roughly half of the problems include a carry so students can
 practice bridging through the tens place.
+
+### Session History
+
+Each training run is appended to `reflex_log.csv` in the project directory.
+The history window lets you review past results and graph reaction times.
+Entries can also be removed via the **選択セッションを削除** button.
+Deleting a session rewrites the CSV immediately and cannot be undone, so
+back up the file manually if you want to keep old records.

--- a/src/app/gui.py
+++ b/src/app/gui.py
@@ -336,6 +336,12 @@ class HistoryWindow(tk.Toplevel):
             self.tree.column(c, width=80, anchor=tk.CENTER)
         self.tree.pack(fill=tk.BOTH, expand=True)
 
+        tk.Button(
+            self,
+            text="選択セッションを削除",
+            command=self.delete_selected,
+        ).pack(pady=5)
+
         self.update_view()
 
     def load_data(self):
@@ -377,6 +383,25 @@ class HistoryWindow(tk.Toplevel):
                     row["slow_count"],
                 ),
             )
+
+    def delete_selected(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        values = self.tree.item(sel[0], "values")
+        if not tk.messagebox.askyesno(
+            "削除確認", f"{values[0]} {values[1]} のセッションを削除しますか?"
+        ):
+            return
+
+        mask = (
+            (self.df["date"].dt.strftime("%Y-%m-%d") == values[0])
+            & (self.df["time"] == values[1])
+            & (self.df["mode"] == values[2])
+        )
+        self.df = self.df[~mask]
+        self.df.to_csv(REFLEX_LOG, index=False)
+        self.update_view()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow deleting sessions from HistoryWindow
- show delete option under the history table
- document irreversible deletions and manual CSV backups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3df07f6c832db0fb1607b0757f27