### PR TITLE
Add runtime deps to CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ visible progress.
    ```bash
    pip install -r requirements.txt
    ```
+   These libraries provide the CSV log handling and reaction time graphs.
 
 ## Quick Start
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 ruff
 black
 pytest


### PR DESCRIPTION
## Summary
- reference requirements.txt from requirements-dev
- clarify that pandas/matplotlib enable history graphs

## Testing
- `pytest -q`
- `pip install -q -r requirements-dev.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686b3e996ec4832db220a719d9155337