### PR TITLE
Add additional drill and logging tests

### DIFF
--- a/tests/test_drill.py
+++ b/tests/test_drill.py
@@ -93,12 +93,14 @@ def test_add2digit2digitdrill_queue_properties():
 
     assert len(q) == 20
     assert len(set(q)) == 20
+    assert len({tuple(sorted(p)) for p in q}) == 20
 
     assert all(10 <= a <= 99 and 10 <= b <= 99 for a, b in q)
     assert all(not (a % 10 == 0 and b % 10 == 0) for a, b in q)
 
     carry = sum(1 for a, b in q if a % 10 + b % 10 >= 10)
     assert carry == 10
+    assert sum(1 for a, b in q if a % 10 + b % 10 < 10) == 10
 
 
 def test_add2digit2digitdrill_disp():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -80,3 +80,19 @@ def test_finish_appends_without_header(tmp_path, monkeypatch):
     assert len(rows) == 2
     assert rows[1][2] == "B"
     assert rows[1][3] == "0.15"
+
+
+def test_finish_uses_mode_d_threshold(tmp_path, monkeypatch):
+    csv_path = tmp_path / "log.csv"
+    monkeypatch.setattr(gui, "REFLEX_LOG", str(csv_path))
+
+    captured = {}
+
+    def capture_slow(slow):
+        captured["slow"] = slow
+
+    app = create_dummy_app("D", [("1", 1.6), ("2", 1.4), ("3", 1.5)])
+    app.show_slow_dialog = capture_slow
+    app.finish()
+
+    assert captured["slow"] == [("1", 1.6)]


### PR DESCRIPTION
## Summary
- strengthen Add2Digit2DigitDrill tests with symmetric duplicate checks and exact carry/non-carry counts
- ensure finish() honours mode D slow threshold

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc3930fcc832db9c9a404fcede39e