### PR TITLE
Allow closing slow dialog with Enter

### DIFF
--- a/src/app/gui.py
+++ b/src/app/gui.py
@@ -305,6 +305,7 @@ class App(tk.Tk):
             ).pack(padx=20, pady=20)
 
         tk.Button(win, text="OK", command=win.destroy).pack(pady=10)
+        win.bind("<Return>", lambda _: win.destroy())
         win.transient(self)
         win.grab_set()
         self.wait_window(win)


### PR DESCRIPTION
## Summary
- enable closing the slow-response popup with the Enter key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879ef4aa538832da04ecab8e7f3e5a0